### PR TITLE
platform/miyoo: Fix CI build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,7 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/dingux-mips32.yml'
 
-  # OpenDingux
+  # OpenDingux (ARM)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/dingux-arm32.yml'
 
@@ -292,8 +292,8 @@ libretro-build-dingux-odbeta-mips32:
     - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs
 
-# OpenDingux
-libretro-build-dingux-arm32:
+# Miyoo
+libretro-build-miyoo-arm32:
   extends:
     - .libretro-miyoo-arm32-make-default
     - .core-defs

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -189,9 +189,7 @@ else ifeq ($(platform), miyoo)
 	SHARED := -shared -Wl,-version-script=link.T
 	CC = /opt/miyoo/usr/bin/arm-linux-gcc
 	AR = /opt/miyoo/usr/bin/arm-linux-ar
-	PLATFORM_DEFINES += -D_GNU_SOURCE
 	CFLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s
-	CFLAGS += -fno-common -ftree-vectorize -funswitch-loops
 
 # Emscripten
 else ifeq ($(platform), emscripten)


### PR DESCRIPTION
Correct the name of the build so the artifact is stored in the right
location. Also remove unnecessary build options.